### PR TITLE
Add support for hyphens in virtual filenames

### DIFF
--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -191,7 +191,7 @@ function defaultAssembleReplacementNodes(
 }
 
 function splitFiles(fullCode: string, folder: string) {
-  const regex = /^\/\/ file: ([\w./]+)(?: (.*))?\s*$/gm;
+  const regex = /^\/\/ file: ([\w\-./]+)(?: (.*))?\s*$/gm;
   let match = regex.exec(fullCode);
 
   let files: VirtualFiles = {};

--- a/test/__snapshots__/transpileCodeblocks.test.ts.snap
+++ b/test/__snapshots__/transpileCodeblocks.test.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`supports hyphens & periods in filenames 1`] = `
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+
+    <Tabs
+      groupId="language"
+      defaultValue="ts"
+      values={[
+        { label: 'TypeScript', value: 'ts', },
+        { label: 'JavaScript', value: 'js', },
+      ]}
+    >        
+        <TabItem value="ts">
+\`\`\`ts
+import { testFn } from './file-one.stuff';
+
+console.log(testFn('foo'));
+\`\`\`
+
+        </TabItem>
+        <TabItem value="js">
+\`\`\`js
+import { testFn } from './file-one.stuff';
+
+console.log(testFn('foo'));
+\`\`\`
+
+        </TabItem>
+    </Tabs>
+`;
+
 exports[`takes "noEmit" files into account for compiling, but does not output them: file1.ts should be missing from this snapshot 1`] = `
 import TabItem from '@theme/TabItem'
 import Tabs from '@theme/Tabs'

--- a/test/transpileCodeblocks.test.ts
+++ b/test/transpileCodeblocks.test.ts
@@ -97,7 +97,7 @@ let x: string = 5
 \`\`\`
 `;
 
-  expect(
+  return expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
@@ -113,7 +113,7 @@ let x: string = 5
 \`\`\`
 `;
 
-  expect(transform(md)).resolves.toMatchInlineSnapshot(`
+  return expect(transform(md)).resolves.toMatchInlineSnapshot(`
     import TabItem from '@theme/TabItem'
     import Tabs from '@theme/Tabs'
     \`\`\`ts
@@ -153,7 +153,7 @@ console.log(testFn(5))
 \`\`\`
 `;
 
-  expect(
+  return expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
@@ -196,11 +196,28 @@ console.log(testFn("foo"))
 \`\`\`
 `;
 
-  expect(
+  return expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
   ).rejects
     .toContain(`remark-typescript-tools/test/test.mdx/codeBlock_1/file1.ts
 Type 'string' is not assignable to type 'number'.`);
+});
+
+test('supports hyphens & periods in filenames', async () => {
+  const md = `
+\`\`\`ts
+// file: file-one.stuff.ts noEmit
+export function testFn(arg1: string) {
+    return arg1;
+}
+// file: file2.ts
+import { testFn } from './file-one.stuff'
+
+console.log(testFn("foo"))
+\`\`\`
+`;
+
+  return expect(transform(md)).resolves.toMatchSnapshot();
 });

--- a/test/transpileCodeblocks.test.ts
+++ b/test/transpileCodeblocks.test.ts
@@ -97,7 +97,7 @@ let x: string = 5
 \`\`\`
 `;
 
-  return expect(
+  await expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
@@ -113,7 +113,7 @@ let x: string = 5
 \`\`\`
 `;
 
-  return expect(transform(md)).resolves.toMatchInlineSnapshot(`
+  await expect(transform(md)).resolves.toMatchInlineSnapshot(`
     import TabItem from '@theme/TabItem'
     import Tabs from '@theme/Tabs'
     \`\`\`ts
@@ -153,7 +153,7 @@ console.log(testFn(5))
 \`\`\`
 `;
 
-  return expect(
+  await expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
@@ -196,7 +196,7 @@ console.log(testFn("foo"))
 \`\`\`
 `;
 
-  return expect(
+  await expect(
     transform(md).catch((e) => {
       throw e.toString();
     })
@@ -219,5 +219,5 @@ console.log(testFn("foo"))
 \`\`\`
 `;
 
-  return expect(transform(md)).resolves.toMatchSnapshot();
+  expect(await transform(md)).toMatchSnapshot();
 });


### PR DESCRIPTION
As per title: adds support for hyphens in virtual filenames

e.g.
```ts
// file: foo-bar.ts noEmit
export const foo = 'foo'

// file: main.ts
import { foo } from './foo-bar'

console.log(foo)
```

Also adds `return`s to the relevant `expect` statements in tests that expected a promise to eventually resolve/throw (otherwise they resolve/throw outside of the tests, and the tests can report false positives)