### PR TITLE
allow overwriting file extensions this plugin runs for

### DIFF
--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -43,6 +43,7 @@ export const attacher: Plugin<[Settings]> = function ({
   postProcessTranspiledJs = defaultPostProcessTranspiledJs,
   postProcessTs = defaultPostProcessTs,
   assembleReplacementNodes = defaultAssembleReplacementNodes,
+  fileExtensions = ['.mdx']
 }) {
   if (!compilers.has(compilerSettings)) {
     compilers.set(compilerSettings, new Compiler(compilerSettings));
@@ -50,7 +51,7 @@ export const attacher: Plugin<[Settings]> = function ({
   const compiler = compilers.get(compilerSettings)!;
 
   return function transformer(tree, file) {
-    if (file.extname !== '.mdx') {
+    if (!fileExtensions.includes(file.extname)) {
       return tree;
     }
 


### PR DESCRIPTION
Nice plugin! I got it mostly working for https://github.com/temporalio/documentation/pull/496, the only issue is that we use `.md` instead of `.mdx` for our MDX files and there's no workaround for running this plugin on .md files.