### PR TITLE
✨ Allow transforming virtual filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ export interface TranspileCodeblocksSettings {
   ) => Node[];
 }
 
+interface CompilerSettings {
+  tsconfig: string;
+  externalResolutions: Record<string, ExternalResolution>;
+  /**
+   * Allows transforming the virtual filepath for codeblocks.
+   * This allows the files to resolve node modules from a different location
+   * to their own directory.
+   */
+  transformVirtualFilepath?: (filepath: string) => string;
+}
+
 interface CodeNode extends Node {
   lang: string;
   meta: string;

--- a/src/transpileCodeblocks/compiler.ts
+++ b/src/transpileCodeblocks/compiler.ts
@@ -21,6 +21,12 @@ export interface ExternalResolution {
 export interface CompilerSettings {
   tsconfig: string;
   externalResolutions: Record<string, ExternalResolution>;
+  /**
+   * Allows transforming the virtual filepath for codeblocks.
+   * This allows the files to resolve node modules from a different location
+   * to their own directory.
+   */
+  transformVirtualFilepath?: (filepath: string) => string;
 }
 
 export class Compiler {

--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -56,6 +56,9 @@ export const attacher: Plugin<[Settings]> = function ({
       return tree;
     }
 
+    const virtualFilepath =
+      compilerSettings.transformVirtualFilepath?.(file.path ?? '') ?? file.path;
+
     let hasTabsImport = false;
     let hasTabItemImport = false;
 
@@ -93,7 +96,7 @@ export const attacher: Plugin<[Settings]> = function ({
         return [node];
       }
 
-      const virtualFolder = `${file.path}/codeBlock_${codeBlock}`;
+      const virtualFolder = `${virtualFilepath}/codeBlock_${codeBlock}`;
       const virtualFiles = splitFiles(node.value, virtualFolder);
 
       //console.time(virtualFolder)


### PR DESCRIPTION
The purpose of this change is to allow virtual files to transform their path to a folder besides the folder their host resides in, which hopefully allows them to resolve node modules from the transformed folder instead.