### PR TITLE
✨ Add option to maintain snippet height

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ interface CompilerSettings {
    * to their own directory.
    */
   transformVirtualFilepath?: (filepath: string) => string;
+  /**
+   * Whether to pad JS snippets with new lines where it would otherwise
+   * be shorter than the corresponding TS snippet.
+   * Not applicable if a custom `assembleReplacementNodes` function is used.
+   */
+  maintainSnippetHeights?: boolean;
 }
 
 interface CodeNode extends Node {

--- a/src/transpileCodeblocks/compiler.ts
+++ b/src/transpileCodeblocks/compiler.ts
@@ -27,6 +27,12 @@ export interface CompilerSettings {
    * to their own directory.
    */
   transformVirtualFilepath?: (filepath: string) => string;
+  /**
+   * Whether to pad JS snippets with new lines where it would otherwise
+   * be shorter than the corresponding TS snippet.
+   * Not applicable if a custom `assembleReplacementNodes` function is used.
+   */
+  maintainSnippetHeights?: boolean;
 }
 
 export class Compiler {

--- a/src/transpileCodeblocks/utils.ts
+++ b/src/transpileCodeblocks/utils.ts
@@ -1,0 +1,4 @@
+/**
+ * Counts the number of lines of a given string
+ */
+export const countLines = (str: string) => str.split(/\r\n|\r|\n/).length;

--- a/test/__snapshots__/transpileCodeblocks.test.ts.snap
+++ b/test/__snapshots__/transpileCodeblocks.test.ts.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Pads line differences 1`] = `
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+
+    <Tabs
+      groupId="language"
+      defaultValue="ts"
+      values={[
+        { label: 'TypeScript', value: 'ts', },
+        { label: 'JavaScript', value: 'js', },
+      ]}
+    >        
+        <TabItem value="ts">
+\`\`\`ts
+import { testFn } from './file1';
+
+console.log(testFn('foo'));
+
+type SpaceFiller = {
+  id: number;
+};
+
+const item: SpaceFiller = {
+  id: 1,
+};
+\`\`\`
+
+        </TabItem>
+        <TabItem value="js">
+\`\`\`js
+import { testFn } from './file1';
+
+console.log(testFn('foo'));
+
+const item = {
+  id: 1,
+};
+
+
+
+
+\`\`\`
+
+        </TabItem>
+    </Tabs>
+`;
+
 exports[`imports defined via compilerOptions.paths import 1`] = `
 import TabItem from '@theme/TabItem'
 import Tabs from '@theme/Tabs'


### PR DESCRIPTION
Allow transpilation to pad JS snippet with newlines
where it would otherwise be shorter than
the corresponding TS snippet

The goal here is to prevent the page height & scroll position from jumping when toggling between TS/JS snippets. I've added it as an opt-in option `maintainSnippetHeights` to `compilerSettings`.