### PR TITLE
✨ Add support for `tsx` codeblocks

### DIFF
--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -88,7 +88,7 @@ export const attacher: Plugin<[Settings]> = function ({
       if (node.type === 'code') {
         codeBlock++;
       }
-      if (!(node.type === 'code' && node.lang === 'ts')) {
+      if (!(node.type === 'code' && ['ts', 'tsx'].includes(node.lang))) {
         return [node];
       }
       const tags = node.meta ? node.meta.split(' ') : [];

--- a/test/__snapshots__/transpileCodeblocks.test.ts.snap
+++ b/test/__snapshots__/transpileCodeblocks.test.ts.snap
@@ -72,6 +72,53 @@ console.log(testFn('foo'));
     </Tabs>
 `;
 
+exports[`supports tsx snippets 1`] = `
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+
+    <Tabs
+      groupId="language"
+      defaultValue="ts"
+      values={[
+        { label: 'TypeScript', value: 'ts', },
+        { label: 'JavaScript', value: 'js', },
+      ]}
+    >        
+        <TabItem value="ts">
+\`\`\`tsx
+import React from 'react';
+export function App() {
+  const [counter, setCounter] = React.useState<number>(0);
+  return (
+    <div>
+      <button onClick={() => setCounter((prev) => prev + 1)}>
+        Increment counter ({counter})
+      </button>
+    </div>
+  );
+}
+\`\`\`
+
+        </TabItem>
+        <TabItem value="js">
+\`\`\`js
+import React from 'react';
+export function App() {
+  const [counter, setCounter] = React.useState(0);
+  return (
+    <div>
+      <button onClick={() => setCounter((prev) => prev + 1)}>
+        Increment counter ({counter})
+      </button>
+    </div>
+  );
+}
+\`\`\`
+
+        </TabItem>
+    </Tabs>
+`;
+
 exports[`takes "noEmit" files into account for compiling, but does not output them: file1.ts should be missing from this snapshot 1`] = `
 import TabItem from '@theme/TabItem'
 import Tabs from '@theme/Tabs'

--- a/test/transpileCodeblocks.test.ts
+++ b/test/transpileCodeblocks.test.ts
@@ -299,3 +299,23 @@ test('transforms virtual filepath', async () => {
     .toContain(`/remark-typescript-tools/replaced/path/test.mdx/codeBlock_1/file2.ts
 Argument of type '5' is not assignable to parameter of type 'string'.`);
 });
+
+test('supports tsx snippets', async () => {
+  const md = `
+\`\`\`tsx title="App.tsx"
+// file: App.tsx
+import React from 'react';
+export function App() {
+  const [counter, setCounter] = React.useState<number>(0);
+  return (
+    <div>
+      <button onClick={() => setCounter((prev) => prev + 1)}>
+        Increment counter ({counter})
+      </button>
+    </div>
+  )
+}
+`;
+
+  expect(await transform(md)).toMatchSnapshot();
+});


### PR DESCRIPTION
Under b7fa5c978350a7046aecf6090e2d77d1ceca4cb2, support was added to allow for jsx transpiling when a file comment such as `// file: App.tsx` was included.

e.g. This was fine
````
```ts
// file: App.tsx
function App() {
  return <div />
}
```
````

However, this still required the snippet to be explicitly specified as `ts`, not `tsx`. 

As a result, the syntax highlighting would not be complete:

`ts` highlighting:
```ts
function App() {
  return <div />
}
```

`tsx` highlighting:
```tsx
function App() {
  return <div />
}
```

This MR allows for also respecting the `tsx` language indicator when transpiling snippets, hence now supporting this:

````
```tsx
// file: App.tsx
function App() {
  return <div />
}
```
````