### PR TITLE
Transform .ts(x) filenames to .js(x)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
 export {
   attacher as transpileCodeblocks,
   Settings as TranspileCodeblocksSettings,
+  defaultAssembleReplacementNodes,
 } from './transpileCodeblocks/plugin';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,8 @@ export {
   attacher as transpileCodeblocks,
   Settings as TranspileCodeblocksSettings,
 } from './transpileCodeblocks/plugin';
+
+export {
+  postProcessTranspiledJs as defaultPostProcessTranspiledJs,
+  postProcessTs as defaultPostProcessTs,
+} from './transpileCodeblocks/postProcessing';

--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -18,7 +18,7 @@ export type VirtualFiles = Record<string, VirtualFile>;
 
 interface CodeNode extends Node {
   lang: string;
-  meta: string;
+  meta: string | null;
   value: string;
   indent: number[];
 }
@@ -143,7 +143,7 @@ ${lines.slice(Math.max(0, diagnostic.line - 5), diagnostic.line + 6).join('\n')}
   };
 };
 
-function defaultAssembleReplacementNodes(
+export function defaultAssembleReplacementNodes(
   node: CodeNode,
   file: VFile,
   virtualFolder: string,
@@ -151,7 +151,7 @@ function defaultAssembleReplacementNodes(
   transpilationResult: Record<string, TranspiledFile>,
   postProcessTs: PostProcessor,
   postProcessTranspiledJs: PostProcessor
-) {
+): Node[] {
   return [
     {
       type: 'jsx',
@@ -182,6 +182,9 @@ function defaultAssembleReplacementNodes(
     {
       ...node,
       lang: 'js',
+      ...(typeof node.meta === 'string' && {
+        meta: node.meta.replace(/(title=['"].*)\.t(sx?)(.*")/, '$1.j$2$3'),
+      }),
       value: rearrangeFiles(
         postProcessTranspiledJs(
           transpilationResult,

--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -201,7 +201,7 @@ function defaultAssembleReplacementNodes(
 }
 
 function splitFiles(fullCode: string, folder: string) {
-  const regex = /^\/\/ file: ([\w\-./]+)(?: (.*))?\s*$/gm;
+  const regex = /^\/\/ file: ([\w\-./\[\]]+)(?: (.*))?\s*$/gm;
   let match = regex.exec(fullCode);
 
   let files: VirtualFiles = {};

--- a/src/transpileCodeblocks/postProcessing.ts
+++ b/src/transpileCodeblocks/postProcessing.ts
@@ -33,7 +33,7 @@ export function postProcessTranspiledJs(
       const prettyCode = prettify(mangledCode, name, parentFile || name);
 
       return [
-        name,
+        name.replace(/.t(sx?)$/, '.j$1'),
         {
           ...file,
           code: prettyCode.trim(),

--- a/test/__snapshots__/transpileCodeblocks.test.ts.snap
+++ b/test/__snapshots__/transpileCodeblocks.test.ts.snap
@@ -85,7 +85,7 @@ import Tabs from '@theme/Tabs'
       ]}
     >        
         <TabItem value="ts">
-\`\`\`tsx
+\`\`\`tsx title="App.tsx" showLineNumbers
 import React from 'react';
 export function App() {
   const [counter, setCounter] = React.useState<number>(0);
@@ -101,7 +101,7 @@ export function App() {
 
         </TabItem>
         <TabItem value="js">
-\`\`\`js
+\`\`\`js title="App.jsx" showLineNumbers
 import React from 'react';
 export function App() {
   const [counter, setCounter] = React.useState(0);

--- a/test/__snapshots__/transpileCodeblocks.test.ts.snap
+++ b/test/__snapshots__/transpileCodeblocks.test.ts.snap
@@ -27,12 +27,12 @@ const n: number = someNumber;
         </TabItem>
         <TabItem value="js">
 \`\`\`js
-// file: file1.ts
+// file: file1.js
 import { someNumber } from '@transpileCodeblocksTest';
 const n = someNumber;
 
 
-// file: file2.ts
+// file: file2.js
 import { someNumber } from '@test/transpileCodeblocks.test';
 const n = someNumber;
 \`\`\`
@@ -41,7 +41,7 @@ const n = someNumber;
     </Tabs>
 `;
 
-exports[`supports hyphens & periods in filenames 1`] = `
+exports[`supports hyphens, square brackets & periods in filenames 1`] = `
 import TabItem from '@theme/TabItem'
 import Tabs from '@theme/Tabs'
 
@@ -210,13 +210,13 @@ console.log(testFn('foo'));
         </TabItem>
         <TabItem value="js">
 \`\`\`js
-// file: file1.ts
+// file: file1.js
 export function testFn(arg1) {
   return arg1;
 }
 
 
-// file: file2.ts
+// file: file2.js
 import { testFn } from './file1';
 
 console.log(testFn('foo'));
@@ -251,6 +251,55 @@ console.log(<div>asd</div>);
 import React from 'react';
 
 console.log(<div>asd</div>);
+\`\`\`
+
+        </TabItem>
+    </Tabs>
+`;
+
+exports[`transpiles multiple jsx files 1`] = `
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+
+    <Tabs
+      groupId="language"
+      defaultValue="ts"
+      values={[
+        { label: 'TypeScript', value: 'ts', },
+        { label: 'JavaScript', value: 'js', },
+      ]}
+    >        
+        <TabItem value="ts">
+\`\`\`ts
+// file: button.tsx
+import React from 'react';
+
+export const Button = (
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>
+) => <button {...props} />;
+
+
+// file: file2.tsx
+import React from 'react';
+import { Button } from './button';
+
+console.log(<Button>asd</Button>);
+\`\`\`
+
+        </TabItem>
+        <TabItem value="js">
+\`\`\`js
+// file: button.jsx
+import React from 'react';
+
+export const Button = (props) => <button {...props} />;
+
+
+// file: file2.jsx
+import React from 'react';
+import { Button } from './button';
+
+console.log(<Button>asd</Button>);
 \`\`\`
 
         </TabItem>

--- a/test/transpileCodeblocks.test.ts
+++ b/test/transpileCodeblocks.test.ts
@@ -12,7 +12,14 @@ expect.addSnapshotSerializer({
   },
   print(value, serialize) {
     if (value.type === 'code') {
-      return '```' + value.lang + '\n' + value.value + '\n```';
+      return (
+        '```' +
+        value.lang +
+        (value.meta ? ' ' + value.meta : '') +
+        '\n' +
+        value.value +
+        '\n```'
+      );
     }
     return value.children
       ? value.children.map(serialize).join('\n')
@@ -321,7 +328,7 @@ Argument of type '5' is not assignable to parameter of type 'string'.`);
 
 test('supports tsx snippets', async () => {
   const md = `
-\`\`\`tsx title="App.tsx"
+\`\`\`tsx title="App.tsx" showLineNumbers
 // file: App.tsx
 import React from 'react';
 export function App() {

--- a/test/transpileCodeblocks.test.ts
+++ b/test/transpileCodeblocks.test.ts
@@ -204,14 +204,14 @@ console.log(testFn("foo"))
 Type 'string' is not assignable to type 'number'.`);
 });
 
-test('supports hyphens & periods in filenames', async () => {
+test('supports hyphens, square brackets & periods in filenames', async () => {
   const md = `
 \`\`\`ts
 // file: file-one.stuff.ts noEmit
 export function testFn(arg1: string) {
     return arg1;
 }
-// file: file2.ts
+// file: [file2].ts
 import { testFn } from './file-one.stuff'
 
 console.log(testFn("foo"))
@@ -263,6 +263,25 @@ console.log(<div>asd</div>)
 \`\`\`
 `;
 
+  expect(await transform(md)).toMatchSnapshot();
+});
+
+test('transpiles multiple jsx files', async () => {
+  const md = `
+\`\`\`ts
+// file: button.tsx
+import React from 'react';
+
+export const Button = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props} />;
+
+// file: file2.tsx
+import React from 'react';
+import { Button } from "./button";
+
+console.log(<Button>asd</Button>);
+
+\`\`\`
+`;
   expect(await transform(md)).toMatchSnapshot();
 });
 


### PR DESCRIPTION
Also:
- add support for square brackets (used by NextJS)
- export default postProcessTs and postProcessTranspiledJs to allow use in custom versions

fixes #11 