### PR TITLE
Make postprocessing sync again

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@microsoft/tsdoc": "^0.15.0",
+    "@prettier/sync": "^0.5.2",
     "@types/estree": "^1.0.5",
     "@types/unist": "^3.0.3",
     "mdast-util-mdx-jsx": "^3.1.3",

--- a/src/transpileCodeblocks/plugin.ts
+++ b/src/transpileCodeblocks/plugin.ts
@@ -31,7 +31,7 @@ type PostProcessor = (
   files: VirtualFiles,
   parentFile?: string,
   defaultProcessor?: PostProcessor
-) => Promise<VirtualFiles>;
+) => VirtualFiles;
 
 export interface TranspileCodeblocksSettings {
   compilerSettings: CompilerSettings;
@@ -212,7 +212,7 @@ ${lines.slice(Math.max(0, diagnostic.line - 5), diagnostic.line + 6).join('\n')}
     };
   };
 
-export async function defaultAssembleReplacementNodes(
+export function defaultAssembleReplacementNodes(
   node: CodeNode,
   file: VFile,
   virtualFolder: string,
@@ -220,7 +220,7 @@ export async function defaultAssembleReplacementNodes(
   transpilationResult: Record<string, TranspiledFile>,
   postProcessTs: PostProcessor,
   postProcessTranspiledJs: PostProcessor
-): Promise<Node[]> {
+): Node[] {
   return [
     {
       type: 'mdxJsxFlowElement',
@@ -334,11 +334,7 @@ export async function defaultAssembleReplacementNodes(
             {
               ...node,
               value: rearrangeFiles(
-                await postProcessTs(
-                  virtualFiles,
-                  file.path,
-                  defaultPostProcessTs
-                ),
+                postProcessTs(virtualFiles, file.path, defaultPostProcessTs),
                 virtualFolder
               ),
             } satisfies CodeNode as any,
@@ -359,7 +355,7 @@ export async function defaultAssembleReplacementNodes(
                 ),
               }),
               value: rearrangeFiles(
-                await postProcessTranspiledJs(
+                postProcessTranspiledJs(
                   transpilationResult,
                   file.path,
                   defaultPostProcessTranspiledJs

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prettier/sync@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@prettier/sync@npm:0.5.2"
+  dependencies:
+    make-synchronized: "npm:^0.2.8"
+  peerDependencies:
+    prettier: "*"
+  checksum: 10/172cdc62f4103b022f8e8d0a63839350d97bc51468ea476594bce651c2cda311e4810417f16a3c967941a8493a68468a5df27beea4c85eaeaa37e84be3acf399
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm-eabi@npm:4.21.1":
   version: 4.21.1
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.21.1"
@@ -2796,6 +2807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-synchronized@npm:^0.2.8":
+  version: 0.2.9
+  resolution: "make-synchronized@npm:0.2.9"
+  checksum: 10/d12c540719641f05f4e40bae5625b7e5ac9dded364e7f97ef3fd8baa1bcbd016f873c5281e4719e321a612635accf0a9e2c07a37d215240b549b99ed0d8a1b3f
+  languageName: node
+  linkType: hard
+
 "mdast-util-from-markdown@npm:^2.0.0":
   version: 2.0.1
   resolution: "mdast-util-from-markdown@npm:2.0.1"
@@ -4108,6 +4126,7 @@ __metadata:
   resolution: "remark-typescript-tools@workspace:."
   dependencies:
     "@microsoft/tsdoc": "npm:^0.15.0"
+    "@prettier/sync": "npm:^0.5.2"
     "@types/estree": "npm:^1.0.5"
     "@types/node": "npm:^22.5.4"
     "@types/react": "npm:^18.3.5"


### PR DESCRIPTION
This PR:

- Generally reverts the asyncification of postprocessing from #15 , as it turns out that the MDX processing does not like nested promises ( refs: https://github.com/unifiedjs/unified/issues/196 , https://github.com/orgs/remarkjs/discussions/1314 )
- Switches to using `@prettier/sync`, as Prettier v3 is async by default